### PR TITLE
Use ADC inplace of Service Account if no creds specified

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ The build cache takes the following options:
 |Option |Description
 
 |credentials
-|JSON key file of the service account to use (required)
+|JSON key file of the service account to use, otherwise GCP Application Default Credentials are used. (optional)
 
 |bucket
 |Name of the Google Cloud Storage bucket (required)
@@ -49,7 +49,7 @@ buildCache {
     }
 
     remote( GCSBuildCache.class ) {
-        credentials = 'my-key.json'
+        credentials = 'my-key.json' // (optional)
         bucket = 'my-bucket'
         refreshAfterSeconds = 86400 // 24h (optional)
         enabled = true
@@ -86,7 +86,7 @@ buildCache {
     registerBuildCacheService( GCSBuildCache.class, GCSBuildCacheServiceFactory.class )
 
     remote( GCSBuildCache.class ) {
-        credentials = 'my-key.json'
+        credentials = 'my-key.json' // (optional)
         bucket = 'my-bucket'
         refreshAfterSeconds = 86400 // 24h (optional)
         enabled = true
@@ -124,7 +124,7 @@ gradle.settingsEvaluated { settings ->
         registerBuildCacheService( GCSBuildCache.class, GCSBuildCacheServiceFactory.class )
 
         remote( GCSBuildCache.class ) {
-            credentials = 'my-key.json'
+            credentials = 'my-key.json' // (optional)
             bucket = 'my-bucket'
             refreshAfterSeconds = 86400 // 24h (optional)
             enabled = true

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -45,9 +45,8 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val refr
     init {
         try {
             val storage = StorageOptions.newBuilder()
-                .setCredentials(credentials.isEmpty() ?
-                    GoogleCredentials.getApplicationDefault() :
-                    ServiceAccountCredentials.fromStream(FileInputStream(credentials))
+                .setCredentials(
+                    if (credentials.isEmpty()) GoogleCredentials.getApplicationDefault() else ServiceAccountCredentials.fromStream(FileInputStream(credentials))
                 )
                 .build()
                 .service

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -15,6 +15,7 @@
  */
 package net.idlestate.gradle.caching
 
+import com.google.auth.oauth2.GoogleCredentials
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.StorageException
@@ -44,7 +45,10 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val refr
     init {
         try {
             val storage = StorageOptions.newBuilder()
-                .setCredentials(ServiceAccountCredentials.fromStream(FileInputStream(credentials)))
+                .setCredentials(credentials.isEmpty() ?
+                    GoogleCredentials.getApplicationDefault() :
+                    ServiceAccountCredentials.fromStream(FileInputStream(credentials))
+                )
                 .build()
                 .service
 

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
@@ -26,13 +26,9 @@ import org.gradle.caching.BuildCacheServiceFactory
  */
 class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
     override fun createBuildCacheService(configuration: GCSBuildCache, describer: BuildCacheServiceFactory.Describer): BuildCacheService {
-        val credentials = configuration.credentials
+        val credentials = (if (configuration.credentials == null) "" else configuration.credentials) as String
         val bucket = configuration.bucket
         val refreshAfterSeconds = configuration.refreshAfterSeconds ?: 0
-
-        if (credentials == null || credentials == "") {
-            throw gradleException("The path to the credentials of the service account has to be defined.")
-        }
 
         if (bucket == null || bucket == "") {
             throw gradleException("The name of the bucket has to be defined.")
@@ -52,7 +48,7 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
                 $message
 
                 remote( GCSBuildCache.class ) {
-                    credentials = 'my-key.json'
+                    credentials = 'my-key.json' // (optional)
                     bucket = 'my-bucket'
                     refreshAfterSeconds = 86400 // 24h (optional)
                     enabled = true


### PR DESCRIPTION
Useful for CI and local where existing gcloud creds or compute engine metadata can be used inplace of a static credential file.